### PR TITLE
Declare dependency on `LambdaCase`

### DIFF
--- a/readcsv.cabal
+++ b/readcsv.cabal
@@ -17,8 +17,9 @@ cabal-version:       >=1.10
 library
   hs-source-dirs:      src
   exposed-modules:     Text.Read.CSV
-  build-depends:       base >= 4 && < 5
+  build-depends:       base >= 4.6 && < 5
   default-language:    Haskell2010
+  other-extensions:    LambdaCase
 
 source-repository head
   type:     git


### PR DESCRIPTION
This makes the cabal solver aware that `readcsv` needs a compiler which supports Haskell2010 + the `LambdaCase` extension.

See also http://cabal.readthedocs.io/en/latest/developing-packages.html#pkg-field-other-extensions